### PR TITLE
Using portable Goldilocks API.

### DIFF
--- a/src/starkpil/zkevm/chelpers/zkevm.chelpers.step2prev.parser.cpp
+++ b/src/starkpil/zkevm/chelpers/zkevm.chelpers.step2prev.parser.cpp
@@ -4,7 +4,7 @@
 #include "constant_pols_starks.hpp"
 #include "zkevmSteps.hpp"
 #include "zkevm.chelpers.step2prev.parser.hpp"
-#include <immintrin.h>
+#include "simd.hpp"
 
 void ZkevmSteps::step2prev_parser_first_avx(StepsParams &params, uint64_t nrows, uint64_t nrowsBatch)
 {
@@ -12,9 +12,9 @@ void ZkevmSteps::step2prev_parser_first_avx(StepsParams &params, uint64_t nrows,
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t offsets1[4], offsets2[4];
           uint64_t numpols = params.pConstPols->numPols();
@@ -929,7 +929,7 @@ void ZkevmSteps::step2prev_parser_first_avx512(StepsParams &params, uint64_t nro
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
           __m512i tmp1[NTEMP1_];
           Goldilocks3::Element_avx512 tmp3[NTEMP3_];

--- a/src/starkpil/zkevm/chelpers/zkevm.chelpers.step3.parser.cpp
+++ b/src/starkpil/zkevm/chelpers/zkevm.chelpers.step3.parser.cpp
@@ -4,7 +4,7 @@
 #include "constant_pols_starks.hpp"
 #include "zkevmSteps.hpp"
 #include "zkevm.chelpers.step3.parser.hpp"
-#include <immintrin.h>
+#include "simd.hpp"
 
 #define AVX_SIZE_ 4
 
@@ -14,10 +14,10 @@ void ZkevmSteps::step3_parser_first_avx(StepsParams &params, uint64_t nrows, uin
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
           uint64_t offsets1[4], offsets2[4];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t numpols = params.pConstPols->numPols();
 
@@ -941,39 +941,39 @@ void ZkevmSteps::step3_parser_first(StepsParams &params, uint64_t nrows, uint64_
 void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows, uint64_t nrowsBatch)
 {
 
-     void (*jumpTable[])(int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols) = {
+     void (*jumpTable[])(int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols) = {
 
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 0:
               Goldilocks::add_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], tmp1[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 1:
               Goldilocks::add_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 2:
               Goldilocks::add_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], Goldilocks::fromU64(args3[i_args + 2]));
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 3:
               Goldilocks::add_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pConstPols->getElement(args3[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 4:
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pols[args3[i_args + 3] + i * args3[i_args + 4]], args3[i_args + 2], args3[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 5:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -984,25 +984,25 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 6:
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pConstPols->getElement(args3[i_args + 3], i), args3[i_args + 2], numpols);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 7:
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], Goldilocks::fromU64(args3[i_args + 3]), args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 8:
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(args3[i_args + 1], i), &params.pConstPols->getElement(args3[i_args + 2], i), numpols, numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 9:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1013,13 +1013,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(0, 0), &params.pConstPols->getElement(0, 0), offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 10:
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(args3[i_args + 1], i), Goldilocks::fromU64(args3[i_args + 2]), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 11:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1029,74 +1029,74 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(0, 0), Goldilocks::fromU64(args3[i_args + 4]), offsets1);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 12:
               Goldilocks3::add13_avx(tmp3[args3[i_args]], tmp1[args3[i_args + 1]], tmp3[args3[i_args + 2]]);
 
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 13:
               Goldilocks3::add1c3c_avx(tmp3[args3[i_args]], Goldilocks::fromU64(args3[i_args + 1]), params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 14:
               Goldilocks3::add13c_avx(tmp3[args3[i_args]], tmp1[args3[i_args + 1]], params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 15:
               Goldilocks3::add13_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp3[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 16:
               Goldilocks3::add13c_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], params.challenges[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 17:
               Goldilocks3::add_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], tmp3[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 18:
               Goldilocks3::add33c_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 19:
               Goldilocks3::add_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp3[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 20:
               Goldilocks3::add33c_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], params.challenges[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 21:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], tmp1[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 22:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 23:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1106,13 +1106,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 24:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp1[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 25:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1122,25 +1122,25 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[0], tmp1[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 26:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], Goldilocks::fromU64(args3[i_args + 2]));
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 27:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), tmp1[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 28:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], Goldilocks::fromU64(args3[i_args + 3]), args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 29:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1150,13 +1150,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[0], Goldilocks::fromU64(args3[i_args + 5]), offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 30:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 31:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1166,13 +1166,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 32:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), &params.pConstPols->getElement(args3[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 33:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1182,13 +1182,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), &params.pConstPols->getElement(0, 0), offsets2);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 34:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], params.publicInputs[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 35:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1199,7 +1199,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 36:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1210,13 +1210,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 37:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pols[args3[i_args + 3] + i * args3[i_args + 4]], args3[i_args + 2], args3[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 38:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1227,61 +1227,61 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 39:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(args3[i_args + 1], i), &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], numpols, args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 40:
               Goldilocks::sub_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pConstPols->getElement(args3[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 41:
               Goldilocks3::sub31c_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], Goldilocks::fromU64(args3[i_args + 3]), args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 42:
               Goldilocks3::sub_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], tmp3[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 43:
               Goldilocks3::sub33c_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 44:
               Goldilocks3::sub_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 45:
               Goldilocks::mult_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], tmp1[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 46:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), tmp1[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 47:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp1[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 48:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1291,19 +1291,19 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[0], tmp1[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 49:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pConstPols->getElement(args3[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 50:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pols[args3[i_args + 3] + i * args3[i_args + 4]], args3[i_args + 2], args3[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 51:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1314,7 +1314,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[args3[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 52:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1325,19 +1325,19 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[args3[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 53:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]), &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 54:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pConstPols->getElement(args3[i_args + 3], i), args3[i_args + 2], numpols);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 55:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1348,13 +1348,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[0], &params.pConstPols->getElement(0, 0), offsets1, offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 56:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], args3[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 57:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1364,37 +1364,37 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 58:
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(args3[i_args + 1], i), tmp1[args3[i_args + 2]], numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 59:
               Goldilocks3::mul13c_avx(tmp3[args3[i_args]], tmp1[args3[i_args + 1]], params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 60:
               Goldilocks3::mul13_avx(tmp3[args3[i_args]], &params.pConstPols->getElement(args3[i_args + 1], i), tmp3[args3[i_args + 2]], numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 61:
               Goldilocks3::mul13_avx(tmp3[args3[i_args]], tmp1[args3[i_args + 1]], tmp3[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 62:
               Goldilocks3::mul13c_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], params.challenges[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 63:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1404,13 +1404,13 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul13c_avx(tmp3[args3[i_args]], &params.pols[0], params.challenges[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 64:
               Goldilocks3::mul13_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp3[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 65:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1421,25 +1421,25 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul13_avx(tmp3[args3[i_args]], &params.pols[0], tmp3[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 66:
               Goldilocks3::mul1c3c_avx(tmp3[args3[i_args]], Goldilocks::fromU64(args3[i_args + 1]), (Goldilocks3::Element &)*params.challenges[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 67:
               Goldilocks3::mul13c_avx(tmp3[args3[i_args]], params.x_n[i], (Goldilocks3::Element &)*params.challenges[args3[i_args + 1]], params.x_n.offset());
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 68:
               Goldilocks3::mul13_avx(tmp3[args3[i_args]], params.x_n[i], tmp3[args3[i_args + 1]], params.x_n.offset());
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 69:
               Goldilocks::Element tmp_inv[3];
@@ -1461,25 +1461,25 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               }
               i_args += 1;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 70:
               Goldilocks3::mul33c_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 2]], params.challenges[args3[i_args + 1]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 71:
               Goldilocks3::mul_avx(tmp3[args3[i_args]], tmp3[args3[i_args + 1]], tmp3[args3[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 72:
               Goldilocks3::mul_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], &params.pols[args3[i_args + 3] + i * args3[i_args + 4]], args3[i_args + 2], args3[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 73:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1490,7 +1490,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul33c_avx(tmp3[args3[i_args]], &params.pols[0], params.challenges[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 74:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1501,19 +1501,19 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul_avx(tmp3[args3[i_args]], &params.pols[0], tmp3[args3[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 75:
               Goldilocks3::mul_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], tmp3[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 76:
               Goldilocks3::mul33c_avx(tmp3[args3[i_args]], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], params.challenges[args3[i_args + 3]], args3[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 77:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1524,19 +1524,19 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul_avx(tmp3[args3[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 78:
               Goldilocks::copy_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]]);
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 79:
               Goldilocks::copy_avx(tmp1[(args3[i_args])], &params.pols[args3[i_args + 1] + i * args3[i_args + 2]], args3[i_args + 2]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 80:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1546,19 +1546,19 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::copy_avx(tmp1[args3[i_args]], &params.pols[0], offsets1);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 81:
               Goldilocks::copy_avx(tmp1[(args3[i_args])], Goldilocks::fromU64(args3[i_args + 1]));
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 82:
               Goldilocks::copy_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(args3[i_args + 1], i), numpols);
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 83:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1568,7 +1568,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::copy_avx(tmp1[(args3[i_args])], &params.pConstPols->getElement(0, 0), offsets1);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 84:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1578,7 +1578,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(tmp1[(args3[i_args])], tmp1[args3[i_args + 1]], &params.pols[0], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 85:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1588,94 +1588,94 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(tmp1[(args3[i_args])], &params.pols[0], Goldilocks::fromU64(args3[i_args + 5]), offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 86:
               Goldilocks::add_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], tmp1[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 87:
               Goldilocks::add_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], &params.pols[args3[i_args + 3] + i * args3[i_args + 4]], args3[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 88:
               Goldilocks3::add13_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], tmp3[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 89:
               Goldilocks3::add_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], tmp3[args3[i_args + 4]], args3[i_args + 3]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 90:
               Goldilocks3::add33c_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp3[args3[i_args + 2]], params.challenges[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 91:
               assert(0);
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 92:
               Goldilocks::sub_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], tmp1[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 93:
               Goldilocks::sub_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], Goldilocks::fromU64(args3[i_args + 2]), tmp1[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 94:
               Goldilocks::mul_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], tmp1[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 95:
               Goldilocks::mul_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], &params.pols[args3[i_args + 2] + i * args3[i_args + 3]], tmp1[args3[i_args + 4]], args3[i_args + 3]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 96:
               Goldilocks::mul_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[args3[i_args + 2]], &params.pConstPols->getElement(args3[i_args + 3], i), numpols);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 97:
               assert(0);
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 98:
               Goldilocks3::mul_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp3[args3[i_args + 2]], tmp3[args3[i_args + 3]]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 99:
               assert(0);
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 100:
               Goldilocks::copy_avx(&params.pols[args3[i_args] + i * args3[i_args + 1]], args3[i_args + 1], tmp1[(args3[i_args + 2])]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 101:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1686,7 +1686,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
 
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 102:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1696,7 +1696,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], &params.pols[args3[i_args + 5] + i * args3[i_args + 6]], args3[i_args + 6]);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 103:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1706,7 +1706,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::add13_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], tmp3[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 104:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1716,7 +1716,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::add_avx(&params.pols[0], offsets1, &params.pols[args3[i_args + 4] + i * args3[i_args + 5]], tmp3[args3[i_args + 6]], args3[i_args + 5]);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 105:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1726,7 +1726,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::add33c_avx(&params.pols[0], offsets1, tmp3[args3[i_args + 4]], params.challenges[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 106:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1736,7 +1736,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], tmp1[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 107:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1746,7 +1746,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::sub_avx(&params.pols[0], offsets1, Goldilocks::fromU64(args3[i_args + 4]), tmp1[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 108:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1756,7 +1756,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], tmp1[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 109:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1766,7 +1766,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(&params.pols[0], offsets1, &params.pols[args3[i_args + 4] + i * args3[i_args + 5]], tmp1[args3[i_args + 6]], args3[i_args + 5]);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 110:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1776,7 +1776,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], &params.pConstPols->getElement(args3[i_args + 5], i), numpols);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 111:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1787,7 +1787,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::mul_avx(&params.pols[0], offsets1, &params.pConstPols->getElement(0, 0), tmp1[args3[i_args + 7]], offsets2);
               i_args += 8;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 112:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1797,7 +1797,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks3::mul_avx(&params.pols[0], offsets1, tmp3[args3[i_args + 4]], tmp3[args3[i_args + 5]]);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 113:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1807,7 +1807,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::copy_avx(&params.pols[0], offsets1, tmp1[(args3[i_args + 4])]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 114:
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1818,7 +1818,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
               Goldilocks::add_avx(&params.pols[0], offsets1, tmp1[args3[i_args + 4]], &params.pols[0], offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 115:
               // 0, 50
@@ -1834,7 +1834,7 @@ void ZkevmSteps::step3_parser_first_avx_jump(StepsParams &params, uint64_t nrows
      {
           int i_args = 0;
           uint64_t offsets1[4], offsets2[4];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t numpols = params.pConstPols->numPols();
           // 2.43172
@@ -1856,7 +1856,7 @@ void ZkevmSteps::step3_parser_first_avx512(StepsParams &params, uint64_t nrows, 
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
           uint64_t offsets1[AVX512_SIZE_], offsets2[AVX512_SIZE_];
           __m512i tmp1[NTEMP1_];

--- a/src/starkpil/zkevm/chelpers/zkevm.chelpers.step3prev.parser.cpp
+++ b/src/starkpil/zkevm/chelpers/zkevm.chelpers.step3prev.parser.cpp
@@ -4,7 +4,7 @@
 #include "constant_pols_starks.hpp"
 #include "zkevmSteps.hpp"
 #include "zkevm.chelpers.step3prev.parser.hpp"
-#include <immintrin.h>
+#include "simd.hpp"
 
 void ZkevmSteps::step3prev_parser_first_avx(StepsParams &params, uint64_t nrows, uint64_t nrowsBatch)
 {
@@ -12,9 +12,9 @@ void ZkevmSteps::step3prev_parser_first_avx(StepsParams &params, uint64_t nrows,
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t offsets1[4], offsets2[4];
           uint64_t numpols = params.pConstPols->numPols();
@@ -929,7 +929,7 @@ void ZkevmSteps::step3prev_parser_first_avx512(StepsParams &params, uint64_t nro
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
           __m512i tmp1[NTEMP1_];
           for (int i = 0; i < NTEMP1_; ++i)

--- a/src/starkpil/zkevm/chelpers/zkevm.chelpers.step42ns.parser.cpp
+++ b/src/starkpil/zkevm/chelpers/zkevm.chelpers.step42ns.parser.cpp
@@ -4,7 +4,7 @@
 #include "constant_pols_starks.hpp"
 #include "zkevmSteps.hpp"
 #include "zkevm.chelpers.step42ns.parser.hpp"
-#include <immintrin.h>
+#include "simd.hpp"
 
 #define AVX_SIZE_ 4
 
@@ -14,9 +14,9 @@ void ZkevmSteps::step42ns_parser_first_avx(StepsParams &params, uint64_t nrows, 
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t offsets1[4], offsets2[4];
           uint64_t numpols = params.pConstPols2ns->numPols();
@@ -1440,39 +1440,39 @@ void ZkevmSteps::step42ns_parser_first(StepsParams &params, uint64_t nrows, uint
 void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nrows, uint64_t nrowsBatch)
 {
 
-     void (*jumpTable[])(int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols) = {
+     void (*jumpTable[])(int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols) = {
 
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 0
               Goldilocks::add_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], tmp1[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 1
               Goldilocks::add_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 2
               Goldilocks::add_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], Goldilocks::fromU64(args42[i_args + 2]));
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 3
               Goldilocks::add_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pConstPols2ns->getElement(args42[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 4
               Goldilocks::add_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pols[args42[i_args + 3] + i * args42[i_args + 4]], args42[i_args + 2], args42[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 5
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1483,25 +1483,25 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::add_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 6
               Goldilocks::add_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pConstPols2ns->getElement(args42[i_args + 3], i), args42[i_args + 2], numpols);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 7
               Goldilocks::add_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], Goldilocks::fromU64(args42[i_args + 3]), args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 8
               Goldilocks::add_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(args42[i_args + 1], i), &params.pConstPols2ns->getElement(args42[i_args + 2], i), numpols, numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 9
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1512,13 +1512,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::add_avx(tmp1[args42[i_args]], &params.pConstPols2ns->getElement(0, 0), &params.pConstPols2ns->getElement(0, 0), offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 10
               Goldilocks::add_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(args42[i_args + 1], i), Goldilocks::fromU64(args42[i_args + 2]), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 11
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1528,73 +1528,73 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::add_avx(tmp1[args42[i_args]], &params.pConstPols2ns->getElement(0, 0), Goldilocks::fromU64(args42[i_args + 4]), offsets1);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 12
               Goldilocks3::add13_avx(tmp3[args42[i_args]], tmp1[args42[i_args + 1]], tmp3[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 13
               Goldilocks3::add1c3c_avx(tmp3[args42[i_args]], Goldilocks::fromU64(args42[i_args + 1]), params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 14
               Goldilocks3::add13c_avx(tmp3[args42[i_args]], tmp1[args42[i_args + 1]], params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 15
               Goldilocks3::add13_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp3[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 16
               Goldilocks3::add13c_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], params.challenges[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 17
               Goldilocks3::add_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], tmp3[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 18
               Goldilocks3::add33c_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 19
               Goldilocks3::add_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp3[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 20
               Goldilocks3::add33c_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], params.challenges[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 21
               Goldilocks::sub_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], tmp1[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 22
               Goldilocks::sub_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 23
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1604,13 +1604,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], tmp1[args42[i_args + 1]], &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 24
               Goldilocks::sub_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp1[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 25
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1620,25 +1620,25 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], &params.pols[0], tmp1[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 26
               Goldilocks::sub_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], Goldilocks::fromU64(args42[i_args + 2]));
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 27
               Goldilocks::sub_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]), tmp1[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 28
               Goldilocks::sub_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], Goldilocks::fromU64(args42[i_args + 3]), args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 29
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1648,13 +1648,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], &params.pols[0], Goldilocks::fromU64(args42[i_args + 5]), offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 30
               Goldilocks::sub_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]), &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 31
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1664,13 +1664,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], Goldilocks::fromU64(args42[i_args + 1]), &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 32
               Goldilocks::sub_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]), &params.pConstPols2ns->getElement(args42[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 33
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1680,13 +1680,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], Goldilocks::fromU64(args42[i_args + 1]), &params.pConstPols2ns->getElement(0, 0), offsets2);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 34
               Goldilocks::sub_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], params.publicInputs[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 35
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1697,7 +1697,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 36
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1708,13 +1708,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 37
               Goldilocks::sub_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pols[args42[i_args + 3] + i * args42[i_args + 4]], args42[i_args + 2], args42[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 38
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1725,61 +1725,61 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::sub_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 39
               Goldilocks::sub_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(args42[i_args + 1], i), &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], numpols, args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 40
               Goldilocks::sub_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pConstPols2ns->getElement(args42[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 41
               Goldilocks3::sub31c_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], Goldilocks::fromU64(args42[i_args + 3]), args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 42
               Goldilocks3::sub_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], tmp3[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 43
               Goldilocks3::sub33c_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 44
               Goldilocks3::sub_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 45
               Goldilocks::mult_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], tmp1[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 46
               Goldilocks::mul_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]), tmp1[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 47
               Goldilocks::mul_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp1[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 48
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1789,19 +1789,19 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], &params.pols[0], tmp1[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 49
               Goldilocks::mul_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pConstPols2ns->getElement(args42[i_args + 2], i), numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 50
               Goldilocks::mul_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pols[args42[i_args + 3] + i * args42[i_args + 4]], args42[i_args + 2], args42[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 51
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1812,7 +1812,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 52
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1823,19 +1823,19 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 9;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 53
               Goldilocks::mul_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]), &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 54
               Goldilocks::mul_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pConstPols2ns->getElement(args42[i_args + 3], i), args42[i_args + 2], numpols);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 55
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1846,13 +1846,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], &params.pols[0], &params.pConstPols2ns->getElement(0, 0), offsets1, offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 56
               Goldilocks::mul_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]], &params.pols[args42[i_args + 2] + i * args42[i_args + 3]], args42[i_args + 3]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 57
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1862,37 +1862,37 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], tmp1[args42[i_args + 1]], &params.pols[0], offsets2);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 58
               Goldilocks::mul_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(args42[i_args + 1], i), tmp1[args42[i_args + 2]], numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 59
               Goldilocks3::mul13c_avx(tmp3[args42[i_args]], tmp1[args42[i_args + 1]], params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 60
               Goldilocks3::mul13_avx(tmp3[args42[i_args]], &params.pConstPols2ns->getElement(args42[i_args + 1], i), tmp3[args42[i_args + 2]], numpols);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 61
               Goldilocks3::mul13_avx(tmp3[args42[i_args]], tmp1[args42[i_args + 1]], tmp3[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 62
               Goldilocks3::mul13c_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], params.challenges[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 63
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1902,13 +1902,13 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul13c_avx(tmp3[args42[i_args]], &params.pols[0], params.challenges[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 64
               Goldilocks3::mul13_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp3[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 65
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1919,25 +1919,25 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul13_avx(tmp3[args42[i_args]], &params.pols[0], tmp3[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 66
               Goldilocks3::mul1c3c_avx(tmp3[args42[i_args]], Goldilocks::fromU64(args42[i_args + 1]), (Goldilocks3::Element &)*params.challenges[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 67
               Goldilocks3::mul13c_avx(tmp3[args42[i_args]], params.x_2ns[i], (Goldilocks3::Element &)*params.challenges[args42[i_args + 1]], params.x_2ns.offset());
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 68
               Goldilocks3::mul13_avx(tmp3[args42[i_args]], params.x_2ns[i], tmp3[args42[i_args + 1]], params.x_2ns.offset());
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 69
               Goldilocks::Element tmp_inv[3];
@@ -1959,25 +1959,25 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               }
               i_args += 1;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 70
               Goldilocks3::mul33c_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 2]], params.challenges[args42[i_args + 1]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 71
               Goldilocks3::mul_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 1]], tmp3[args42[i_args + 2]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 72
               Goldilocks3::mul_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pols[args42[i_args + 3] + i * args42[i_args + 4]], args42[i_args + 2], args42[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 73
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1988,7 +1988,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul33c_avx(tmp3[args42[i_args]], &params.pols[0], params.challenges[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 74
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -1999,19 +1999,19 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul_avx(tmp3[args42[i_args]], &params.pols[0], tmp3[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 75
               Goldilocks3::mul_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], tmp3[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 76
               Goldilocks3::mul33c_avx(tmp3[args42[i_args]], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], params.challenges[args42[i_args + 3]], args42[i_args + 2]);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 77
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -2022,19 +2022,19 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul_avx(tmp3[args42[i_args]], &params.pols[0], &params.pols[0], offsets1, offsets2);
               i_args += 7;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 78
               Goldilocks::copy_avx(tmp1[(args42[i_args])], tmp1[args42[i_args + 1]]);
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 79
               Goldilocks::copy_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], args42[i_args + 2]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 80
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -2044,19 +2044,19 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::copy_avx(tmp1[args42[i_args]], &params.pols[0], offsets1);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 81
               Goldilocks::copy_avx(tmp1[(args42[i_args])], Goldilocks::fromU64(args42[i_args + 1]));
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 82
               Goldilocks::copy_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(args42[i_args + 1], i), numpols);
               i_args += 2;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 83
               for (uint64_t j = 0; j < AVX_SIZE_; ++j)
@@ -2066,7 +2066,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::copy_avx(tmp1[(args42[i_args])], &params.pConstPols2ns->getElement(0, 0), offsets1);
               i_args += 4;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 84
               // 12 - 70: 1918
@@ -2075,7 +2075,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul33c_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 2]], params.challenges[args42[i_args + 1]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 85
               // 0 - 50: 1462
@@ -2084,7 +2084,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[(args42[i_args])], &params.pols[args42[i_args + 1] + i * args42[i_args + 2]], &params.pols[args42[i_args + 3] + i * args42[i_args + 4]], args42[i_args + 2], args42[i_args + 4]);
               i_args += 5;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 86
               //  32, 47, 21, 32, 48: 166
@@ -2103,7 +2103,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks::mul_avx(tmp1[args42[i_args]], &params.pols[0], tmp1[args42[i_args + 5]], offsets1);
               i_args += 6;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 87
               //  84, 84, 84, 84,
@@ -2124,7 +2124,7 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
               Goldilocks3::mul33c_avx(tmp3[args42[i_args]], tmp3[args42[i_args + 2]], params.challenges[args42[i_args + 1]]);
               i_args += 3;
          },
-         [](int i, int &i_args, __m256i tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
+         [](int i, int &i_args, u64x4 tmp1[NTEMP1_], Goldilocks3::Element_avx tmp3[NTEMP3_], uint64_t offsets1[4], uint64_t offsets2[4], StepsParams &params, const int numpols)
          {
               // 88
               //  21, 50, 21, 53, 0, 85, 50, 85, 21, 50,
@@ -2160,9 +2160,9 @@ void ZkevmSteps::step42ns_parser_first_avx_jump(StepsParams &params, uint64_t nr
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
           int i_args = 0;
-          //__m256i *tmp1 = new __m256i[NTEMP1_];
+          //u64x4 *tmp1 = new u64x4[NTEMP1_];
           // Goldilocks3::Element_avx *tmp3 = new Goldilocks3::Element_avx[NTEMP3_];
-          __m256i tmp1[NTEMP1_];
+          u64x4 tmp1[NTEMP1_];
           Goldilocks3::Element_avx tmp3[NTEMP3_];
           uint64_t offsets1[4], offsets2[4];
           uint64_t numpols = params.pConstPols2ns->numPols();

--- a/src/starkpil/zkevm/chelpers/zkevm.chelpers.step52ns.parser.cpp
+++ b/src/starkpil/zkevm/chelpers/zkevm.chelpers.step52ns.parser.cpp
@@ -4,7 +4,7 @@
 #include "constant_pols_starks.hpp"
 #include "zkevmSteps.hpp"
 #include "zkevm.chelpers.step52ns.parser.hpp"
-#include <immintrin.h>
+#include "simd.hpp"
 
 void ZkevmSteps::step52ns_parser_first_avx(StepsParams &params, uint64_t nrows, uint64_t nrowsBatch)
 {
@@ -12,9 +12,9 @@ void ZkevmSteps::step52ns_parser_first_avx(StepsParams &params, uint64_t nrows, 
 #pragma omp parallel for
      for (uint64_t i = 0; i < nrows; i += nrowsBatch)
      {
-          __m256i tmp0_0, tmp0_1, tmp0_2;
-          __m256i tmp1_0, tmp1_1, tmp1_2;
-          __m256i tmp2_0, tmp2_1, tmp2_2;
+          u64x4 tmp0_0, tmp0_1, tmp0_2;
+          u64x4 tmp1_0, tmp1_1, tmp1_2;
+          u64x4 tmp2_0, tmp2_1, tmp2_2;
 
           tmp2_0 = _mm256_setzero_si256();
           tmp2_1 = _mm256_setzero_si256();
@@ -36,10 +36,10 @@ void ZkevmSteps::step52ns_parser_first_avx(StepsParams &params, uint64_t nrows, 
 
           Goldilocks::Element aux0_ops[4], aux1_ops[4], aux2_ops[4];
           Goldilocks::Element aux0[4], aux1[4], aux2[4];
-          __m256i chall50_, chall51_, chall52_;
-          __m256i chall5o0_, chall5o1_, chall5o2_;
-          __m256i chall60_, chall61_, chall62_;
-          __m256i chall6o0_, chall6o1_, chall6o2_;
+          u64x4 chall50_, chall51_, chall52_;
+          u64x4 chall5o0_, chall5o1_, chall5o2_;
+          u64x4 chall60_, chall61_, chall62_;
+          u64x4 chall6o0_, chall6o1_, chall6o2_;
 
           for (int k = 0; k < AVX_SIZE_; ++k)
           {


### PR DESCRIPTION
We still need to use AVX2, but at least now immintrin.h header is confined to goldilocks. This is a first step in making the code portable.